### PR TITLE
Fix for issue #63 and #59. Add timezone-picker package to detect client-side timezones.

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -92,6 +92,7 @@ telescope-settings
 telescope-sitemap
 telescope-messages
 telescope-pages
+
 # Custom Packages
 cb-theme-pages
 cb-theme
@@ -101,4 +102,4 @@ mizzao:user-status
 mrt:moment-timezone
 mrt:mediaqueries
 meteorhacks:kadira@2.20.1
-
+joshowens:timezone-picker

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -56,6 +56,7 @@ iron:location@1.0.7
 iron:middleware-stack@1.0.7
 iron:router@1.0.7
 iron:url@1.0.7
+joshowens:timezone-picker@0.1.2
 jparker:crypto-core@0.1.0
 jparker:crypto-md5@0.1.1
 jparker:gravatar@0.3.1

--- a/packages/cb-theme-pages/lib/client/templates/new_post_title.js
+++ b/packages/cb-theme-pages/lib/client/templates/new_post_title.js
@@ -7,7 +7,7 @@ Template[getTemplate('newPostTitle')].helpers({
     return !!this.url ? '_blank' : '';
   },
   formattedHangoutDate: function() {
-    var tz = Intl.DateTimeFormat().resolvedOptions().timeZone ? Intl.DateTimeFormat().resolvedOptions().timeZone : ''
+    var tz = TimezonePicker.detectedZone();
     if (this.scheduledFor) {
       // Don't bother to show time for past hangouts. Cuz who cares yo.
         if (tz.length===0) {
@@ -26,7 +26,7 @@ Template[getTemplate('newPostTitle')].helpers({
     }
   },
   endHangoutDate: function() {
-    var tz = Intl.DateTimeFormat().resolvedOptions().timeZone ? Intl.DateTimeFormat().resolvedOptions().timeZone : ''
+    var tz = TimezonePicker.detectedZone();
     if (this.scheduledEnd) {
       // Time for when the hangout ends.
       if (tz.length===0) {


### PR DESCRIPTION
The timezone-picker package seems to do the trick (for now) for detecting the user's timezone. I only tested it on the latest versions of Firefox, Chrome, Opera, and Safari on a Mac. I came across it after finding this blog post:

http://joshowens.me/dealing-with-timezones-in-javascript/
